### PR TITLE
protection from deref'ing undefs

### DIFF
--- a/lib/WebKeePass/DB.pm
+++ b/lib/WebKeePass/DB.pm
@@ -68,8 +68,8 @@ sub _build_entries {
     my @entries;
 
     my $count = 0;
-    foreach my $group (map { $_->{groups} } @{ $groups }) {
-        foreach my $entry (map { @{ $_->{entries} } } @{ $group }) {
+    foreach my $group (map { $_->{groups} || [$_] } @{ $groups }) {
+        foreach my $entry (map { @{ $_->{entries} || [] } } @{ $group }) {
 
             my ( $title, $username, $password ) =
               ( $entry->{title}, $entry->{username}, $entry->{password} );


### PR DESCRIPTION
In my keepass file, the groups don't have subgroups,
and some of them have no entries
